### PR TITLE
configure.ac: C99 compatibility fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -996,7 +996,9 @@ test_for_epoll()
 {
   AC_CHECK_HEADERS(sys/epoll.h)
   AC_MSG_CHECKING(for epoll functions)
-  AC_TRY_LINK([#include <sys/epoll.h>], [
+  AC_TRY_LINK([#include <sys/epoll.h>
+	#include <unistd.h>
+	], [
 	int fd;
 	fd = epoll_create(1);
 	close(fd);
@@ -1270,7 +1272,7 @@ AC_MSG_CHECKING(if dlfns needs explicit library request)
 AC_LINK_IFELSE([AC_LANG_SOURCE([
 #define _GNU_SOURCE 1
 #include <dlfcn.h>
-main() {void *p = dlsym(RTLD_DEFAULT,"sym");}
+int main(void) {void *p = dlsym(RTLD_DEFAULT,"sym");}
 ])],[
     AC_MSG_RESULT(no)
 ],[


### PR DESCRIPTION
Avoid implicit function declarations and implicit int, for improved compatibility with future compilers which no longer support these language features by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
